### PR TITLE
Patch redirect_uri with current absolute URI

### DIFF
--- a/social_core/backends/apple.py
+++ b/social_core/backends/apple.py
@@ -129,3 +129,7 @@ class AppleIdAuth(BaseOAuth2):
 
         decoded_data = self.decode_id_token(jwt_string)
         return super(AppleIdAuth, self).do_auth(access_token, response=decoded_data, *args, **kwargs)
+
+    def get_redirect_uri(self, state=None):
+        """Patch redirect_uri with current absolute URI"""
+        return self.strategy.absolute_uri()      


### PR DESCRIPTION
If fixes `invalid grant` authentication flow errors from AppleID responses  // {'error': 'invalid_grant'}

Needed to ensure that the `redirect_uri` (param inside the `auth_complete` payload) matchs the original `redirect_uri` requested to the AppleID sign in service (i.e. https://appleid.apple.com/auth/authorize).